### PR TITLE
Support configurable output path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ module.exports = function(gulp, options) {
     testsDirName: options.testsDirName || (separateTests ? 'tests' : '_tests'),
     glob: separateTests ? [scriptsDirName + '/**/*', testsDirName + '/**/*'] : scriptsDirName + '/**/*',
     initFunction: options.init ? ('(' + options.init + ')();') : '',
-    outputPath: './.test',
+    outputPath: options.outputPath || './.test',
     gulp: gulp
   });
   options.mochaOptions = getMochaOptions(options);


### PR DESCRIPTION
This means multiple `gulp test ...` scripts can be run in parallel.
